### PR TITLE
Update to upstream version 0.1.5

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,7 +6,7 @@ Checklist
 * [ ] Used a fork of the feedstock to propose changes
 * [ ] Bumped the build number (if the version is unchanged)
 * [ ] Reset the build number to `0` (if the version changed)
-* [ ] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy`
+* [ ] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
 * [ ] Ensured the license file is being packaged.
 
 <!--

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = '0.1.4' %}
+{% set version = '0.1.5' %}
 
 {% set posix = 'm2-' if win else '' %}
 {% set native = 'm2w64-' if win else '' %}
@@ -12,7 +12,7 @@ source:
   url:
     - {{ cran_mirror }}/src/contrib/aws.ec2metadata_{{ version }}.tar.gz
     - {{ cran_mirror }}/src/contrib/Archive/aws.ec2metadata/aws.ec2metadata_{{ version }}.tar.gz
-  sha256: 5cab4cedb64b924479f55ca3812dff6b952b85af6107016736ce5061b17d8122
+  sha256: 3bd0cc28c266ecbc5b3463546750c5a44ff7a35aaba90de73ec30b2f9bb8fb1c
 
 build:
   merge_build_host: True  # [win]
@@ -24,6 +24,7 @@ build:
 
 requirements:
   build:
+    - {{posix}}zip               # [win]
 
   host:
     - r-base


### PR DESCRIPTION
Also add zip dependency as suggested by conda skeleton cran, see also
https://github.com/conda/conda-build/pull/3030

Checklist
* [*] Used a fork of the feedstock to propose changes
* [*] Reset the build number to `0` (if the version changed)
* [*] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy`
* [*] Ensured the license file is being packaged.